### PR TITLE
Add script to gather key Cyber Hygiene metrics

### DIFF
--- a/scripts/gather_key_cyhy_metrics.sh
+++ b/scripts/gather_key_cyhy_metrics.sh
@@ -25,13 +25,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-if [ $# -eq 5 ]; then
-  cyhy_db_fqdn=$1
-  cyhy_reporter_fqdn=$2
-  cyhy_mongodb_uri=$3
-  cyhy_mongodb_username=$4
-  cyhy_mongodb_password=$5
-else
+if [ $# -ne 5 ]; then
   cat << END_OF_LINE
 Usage:  ${0##*/} cyhy_db_fqdn cyhy_reporter_fqdn cyhy_mongodb_uri cyhy_mongodb_username cyhy_mongodb_password
 
@@ -44,6 +38,12 @@ cyhy_mongodb_password: The MongoDB password for the Cyber Hygiene database
 END_OF_LINE
   exit 1
 fi
+
+cyhy_db_fqdn=$1
+cyhy_reporter_fqdn=$2
+cyhy_mongodb_uri=$3
+cyhy_mongodb_username=$4
+cyhy_mongodb_password=$5
 
 today=$(date +%Y-%m-%d)
 

--- a/scripts/gather_key_cyhy_metrics.sh
+++ b/scripts/gather_key_cyhy_metrics.sh
@@ -32,13 +32,16 @@ if [ $# -eq 5 ]; then
   cyhy_mongodb_username=$4
   cyhy_mongodb_password=$5
 else
-  echo "Usage:  gather_key_cyhy_metrics.sh cyhy_db_fqdn cyhy_reporter_fqdn cyhy_mongodb_uri cyhy_mongodb_username cyhy_mongodb_password"
-  echo
-  echo "cyhy_db_fqdn: The fully qualified domain name of the Cyber Hygiene database server (e.g. \"database.example.gov\")"
-  echo "cyhy_reporter_fqdn: The fully qualified domain name of the Cyber Hygiene reporter server (e.g. \"reporter.example.gov\")"
-  echo "cyhy_mongodb_uri: The MongoDB URI for the Cyber Hygiene database (e.g. \"mongodb://localhost:27017/cyhy\" or \"localhost/cyhy\")"
-  echo "cyhy_mongodb_username: The MongoDB username for the Cyber Hygiene database"
-  echo "cyhy_mongodb_password: The MongoDB password for the Cyber Hygiene database"
+  cat << END_OF_LINE
+Usage:  ${0##*/} cyhy_db_fqdn cyhy_reporter_fqdn cyhy_mongodb_uri cyhy_mongodb_username cyhy_mongodb_password
+
+cyhy_db_fqdn: The fully qualified domain name of the Cyber Hygiene database server (e.g. "database.example.gov")
+cyhy_reporter_fqdn: The fully qualified domain name of the Cyber Hygiene reporter server (e.g. "reporter.example.gov")
+cyhy_mongodb_uri: The MongoDB URI for the Cyber Hygiene database (e.g. "mongodb://localhost:27017/cyhy" or "localhost/cyhy")
+cyhy_mongodb_username: The MongoDB username for the Cyber Hygiene database
+cyhy_mongodb_password: The MongoDB password for the Cyber Hygiene database
+
+END_OF_LINE
   exit 1
 fi
 

--- a/scripts/gather_key_cyhy_metrics.sh
+++ b/scripts/gather_key_cyhy_metrics.sh
@@ -76,9 +76,13 @@ for stage in "${scan_stages[@]}"; do
 done
 
 # WEEKLY REPORTING METRICS
-weekly_snapshots_duration_minutes=$(ssh "$cyhy_reporter_fqdn" "tail --lines 10 /var/cyhy/reports/output/snapshots_reports_scorecard_automation.log | grep 'Time to generate snapshots' | cut --delimiter ' ' --fields 9")
-weekly_reports_duration_minutes=$(ssh "$cyhy_reporter_fqdn" "tail --lines 10 /var/cyhy/reports/output/snapshots_reports_scorecard_automation.log | grep 'Time to generate reports' | cut --delimiter ' ' --fields 9")
-weekly_total_reporting_duration_minutes=$(ssh "$cyhy_reporter_fqdn" "tail --lines 10 /var/cyhy/reports/output/snapshots_reports_scorecard_automation.log | grep 'Total time' | cut --delimiter ' ' --fields 7")
+weekly_reporting_text=$(ssh "$cyhy_reporter_fqdn" "tail --lines 10 /var/cyhy/reports/output/snapshots_reports_scorecard_automation.log")
+
+# Note: The macOS default "cut" command does not support the long flag names
+# for --delimeter and --fields.
+weekly_snapshots_duration_minutes=$(echo "$weekly_reporting_text" | grep 'Time to generate snapshots' | cut -d' ' -f9)
+weekly_reports_duration_minutes=$(echo "$weekly_reporting_text" | grep 'Time to generate reports' | cut -d' ' -f9)
+weekly_total_reporting_duration_minutes=$(echo "$weekly_reporting_text" | grep 'Total time' | cut -d' ' -f7)
 
 # WEEKLY DATABASE ARCHIVE METRICS
 weekly_cyhy_db_archive_duration_minutes=$(ssh "$cyhy_db_fqdn" "grep 'successfully completed' \$(ls -rt /var/log/cyhy/archive.log-* | tail --lines 1) | grep --only-matching '(.*)' | sed 's/[( minutes)]//g'")

--- a/scripts/gather_key_cyhy_metrics.sh
+++ b/scripts/gather_key_cyhy_metrics.sh
@@ -50,9 +50,15 @@ today=$(date +%Y-%m-%d)
 # COMMANDER MAIN LOOP DURATION METRICS
 # NOTE: These metrics are pulled from all existing (non-compressed) commander
 # logs, not just the most recent one.
-commander_duration_mean=$(ssh "$cyhy_db_fqdn" "grep --only-matching --perl-regexp 'Last cycle took .* seconds' /var/log/cyhy/commander.log* | awk '{ total += \$4; count++ } END { print total/count }'")
-commander_duration_median=$(ssh "$cyhy_db_fqdn" "grep --only-matching --perl-regexp 'Last cycle took .* seconds' /var/log/cyhy/commander.log* | cut --delimiter ' ' --fields 4 | sort --numeric-sort | awk '{ a[i++]=\$1; } END { print a[int(i/2)]; }'")
-commander_duration_max=$(ssh "$cyhy_db_fqdn" "grep --only-matching --perl-regexp 'Last cycle took .* seconds' /var/log/cyhy/commander.log* | cut --delimiter ' ' --fields 4 | sort --numeric-sort | tail --lines 1")
+commander_duration_text=$(ssh "$cyhy_db_fqdn" "grep --only-matching --perl-regexp 'Last cycle took [\d.]* seconds' /var/log/cyhy/commander.log*")
+
+# echo "$commander_duration_text" preserves newlines; without this, the awk
+# command does not work correctly.
+commander_duration_mean=$(echo "$commander_duration_text" | awk '{ total += $4; count++ } END { print total/count }')
+# Note: The macOS default "cut" command does not support the long flag names
+# for --delimeter and --fields.
+commander_duration_median=$(echo "$commander_duration_text" | cut -d' ' -f4 | sort --numeric-sort | awk '{ a[i++]=$1; } END { print a[int(i/2)]; }')
+commander_duration_max=$(echo "$commander_duration_text" | cut -d' ' -f4 | sort --numeric-sort | tail --lines 1)
 
 # COMMANDER SCAN BACKLOG METRICS
 scan_stages=("NETSCAN1" "NETSCAN2" "PORTSCAN" "VULNSCAN")

--- a/scripts/gather_key_cyhy_metrics.sh
+++ b/scripts/gather_key_cyhy_metrics.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# A script to gather key Cyber Hygiene metrics from various sources.  Output
+# is a header row and a single line of comma-separated values.
+#
+# Usage:
+# gather_key_cyhy_metrics.sh cyhy_db_fqdn cyhy_reporter_fqdn cyhy_mongodb_uri \
+#   cyhy_mongodb_username cyhy_mongodb_password
+#
+# - cyhy_db_fqdn: The fully qualified domain name of the Cyber Hygiene database
+# server (e.g. "database.example.gov")
+# - cyhy_reporter_fqdn: The fully qualified domain name of the Cyber Hygiene
+# reporter server (e.g. "reporter.example.gov")
+# - cyhy_mongodb_uri: The MongoDB URI for the Cyber Hygiene database (e.g.
+# "mongodb://localhost:27017/cyhy" or "localhost/cyhy")
+# - cyhy_mongodb_username: The MongoDB username for the Cyber Hygiene database
+# - cyhy_mongodb_password: The MongoDB password for the Cyber Hygiene database
+#
+# Requires:
+# - SSH access to the Cyber Hygiene database and reporter servers
+# - mongosh installed
+# - A MongoDB user with read access to the Cyber Hygiene database
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+if [ $# -eq 5 ]; then
+  cyhy_db_fqdn=$1
+  cyhy_reporter_fqdn=$2
+  cyhy_mongodb_uri=$3
+  cyhy_mongodb_username=$4
+  cyhy_mongodb_password=$5
+else
+  echo "Usage:  gather_key_cyhy_metrics.sh cyhy_db_fqdn cyhy_reporter_fqdn cyhy_mongodb_uri cyhy_mongodb_username cyhy_mongodb_password"
+  echo
+  echo "cyhy_db_fqdn: The fully qualified domain name of the Cyber Hygiene database server (e.g. \"database.example.gov\")"
+  echo "cyhy_reporter_fqdn: The fully qualified domain name of the Cyber Hygiene reporter server (e.g. \"reporter.example.gov\")"
+  echo "cyhy_mongodb_uri: The MongoDB URI for the Cyber Hygiene database (e.g. \"mongodb://localhost:27017/cyhy\" or \"localhost/cyhy\")"
+  echo "cyhy_mongodb_username: The MongoDB username for the Cyber Hygiene database"
+  echo "cyhy_mongodb_password: The MongoDB password for the Cyber Hygiene database"
+  exit 1
+fi
+
+today=$(date +%Y-%m-%d)
+
+# COMMANDER MAIN LOOP DURATION METRICS
+# NOTE: These metrics are pulled from all existing (non-compressed) commander
+# logs, not just the most recent one.
+commander_duration_mean=$(ssh "$cyhy_db_fqdn" "grep --only-matching --perl-regexp 'Last cycle took .* seconds' /var/log/cyhy/commander.log* | awk '{ total += \$4; count++ } END { print total/count }'")
+commander_duration_median=$(ssh "$cyhy_db_fqdn" "grep --only-matching --perl-regexp 'Last cycle took .* seconds' /var/log/cyhy/commander.log* | cut --delimiter ' ' --fields 4 | sort --numeric-sort | awk '{ a[i++]=\$1; } END { print a[int(i/2)]; }'")
+commander_duration_max=$(ssh "$cyhy_db_fqdn" "grep --only-matching --perl-regexp 'Last cycle took .* seconds' /var/log/cyhy/commander.log* | cut --delimiter ' ' --fields 4 | sort --numeric-sort | tail --lines 1")
+
+# COMMANDER SCAN BACKLOG METRICS
+scan_stages=("NETSCAN1" "NETSCAN2" "PORTSCAN" "VULNSCAN")
+
+# Hosts with non-zero priority
+declare -A nonzero_priority_waiting_count
+for stage in "${scan_stages[@]}"; do
+  nonzero_priority_waiting_count[$stage]=$(mongosh --quiet "$cyhy_mongodb_uri" --username "$cyhy_mongodb_username" --password "$cyhy_mongodb_password" --eval "db.hosts.countDocuments({'status': 'WAITING', 'priority': {\$ne: 0}, 'stage':'$stage'})")
+done
+
+# Hosts with zero priority
+declare -A zero_priority_waiting_count
+for stage in "${scan_stages[@]}"; do
+  zero_priority_waiting_count[$stage]=$(mongosh --quiet "$cyhy_mongodb_uri" --username "$cyhy_mongodb_username" --password "$cyhy_mongodb_password" --eval "db.hosts.countDocuments({'status': 'WAITING', 'priority': 0, 'stage':'$stage'})")
+done
+
+# WEEKLY REPORTING METRICS
+weekly_snapshots_duration_minutes=$(ssh "$cyhy_reporter_fqdn" "tail --lines 10 /var/cyhy/reports/output/snapshots_reports_scorecard_automation.log | grep 'Time to generate snapshots' | cut --delimiter ' ' --fields 9")
+weekly_reports_duration_minutes=$(ssh "$cyhy_reporter_fqdn" "tail --lines 10 /var/cyhy/reports/output/snapshots_reports_scorecard_automation.log | grep 'Time to generate reports' | cut --delimiter ' ' --fields 9")
+weekly_total_reporting_duration_minutes=$(ssh "$cyhy_reporter_fqdn" "tail --lines 10 /var/cyhy/reports/output/snapshots_reports_scorecard_automation.log | grep 'Total time' | cut --delimiter ' ' --fields 7")
+
+# WEEKLY DATABASE ARCHIVE METRICS
+weekly_cyhy_db_archive_duration_minutes=$(ssh "$cyhy_db_fqdn" "grep 'successfully completed' \$(ls -rt /var/log/cyhy/archive.log-* | tail --lines 1) | grep --only-matching '(.*)' | sed 's/[( minutes)]//g'")
+
+# DAILY CYHY FEED METRICS
+daily_cyhy_feed_duration_minutes=$(ssh "$cyhy_db_fqdn" "grep 'Finished data extraction process' /var/log/cyhy/feeds.log | cut --delimiter ' ' --fields 2 | awk -F: '{print (\$1 * 60) + \$2}'")
+
+# OUTPUT RESULTS
+echo "Date,Commander Main Loop Duration Mean (sec),Commander Main Loop Duration Median (sec),Commander Main Loop Duration Max (sec),NETSCAN1 hosts waiting (non-zero priority),NETSCAN2 hosts waiting (non-zero priority),PORTSCAN hosts waiting (non-zero priority),VULNSCAN hosts waiting (non-zero priority),NETSCAN1 hosts waiting (zero priority),NETSCAN2 hosts waiting (zero priority),PORTSCAN hosts waiting (zero priority),VULNSCAN hosts waiting (zero priority),Weekly Snapshots Duration (min),Weekly Reports Duration (min),Weekly Total Reporting Duration (min),Weekly CyHy DB Archive Duration (min),Daily CyHy Feed Duration (min)"
+echo "$today,$commander_duration_mean,$commander_duration_median,$commander_duration_max,${nonzero_priority_waiting_count[NETSCAN1]},${nonzero_priority_waiting_count[NETSCAN2]},${nonzero_priority_waiting_count[PORTSCAN]},${nonzero_priority_waiting_count[VULNSCAN]},${zero_priority_waiting_count[NETSCAN1]},${zero_priority_waiting_count[NETSCAN2]},${zero_priority_waiting_count[PORTSCAN]},${zero_priority_waiting_count[VULNSCAN]},$weekly_snapshots_duration_minutes,$weekly_reports_duration_minutes,$weekly_total_reporting_duration_minutes,$weekly_cyhy_db_archive_duration_minutes,$daily_cyhy_feed_duration_minutes"
+
+exit 0

--- a/scripts/gather_key_cyhy_metrics.sh
+++ b/scripts/gather_key_cyhy_metrics.sh
@@ -18,7 +18,7 @@
 #
 # Requires:
 # - SSH access to the Cyber Hygiene database and reporter servers
-# - mongosh installed
+# - mongosh installed; see https://www.mongodb.com/docs/mongodb-shell/install/
 # - A MongoDB user with read access to the Cyber Hygiene database
 
 set -o nounset

--- a/scripts/gather_key_cyhy_metrics.sh
+++ b/scripts/gather_key_cyhy_metrics.sh
@@ -52,8 +52,6 @@ today=$(date +%Y-%m-%d)
 # logs, not just the most recent one.
 commander_duration_text=$(ssh "$cyhy_db_fqdn" "grep --only-matching --perl-regexp 'Last cycle took [\d.]* seconds' /var/log/cyhy/commander.log*")
 
-# echo "$commander_duration_text" preserves newlines; without this, the awk
-# command does not work correctly.
 commander_duration_mean=$(echo "$commander_duration_text" | awk '{ total += $4; count++ } END { print total/count }')
 # Note: The macOS default "cut" command does not support the long flag names
 # for --delimeter and --fields.


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a script to gather key Cyber Hygiene metrics from various sources (database and reporter logs, CyHy database).  The script output is a header row and a single line of comma-separated values.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

As our CyHy system grows, we need an easy way to keep tabs on certain key metrics.  This script (`gather_key_cyhy_metrics.sh`) allows us to easily do that.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I have run the script and ensures that it outputs the intended data.  I also confirmed that the usage information is displayed if the incorrect number of parameters are passed to the script.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
